### PR TITLE
Emit loud warning annotations when publish tokens are missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,11 +190,19 @@ jobs:
         env:
           TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
         run: |
+          # Emitting `::warning::` (rather than a plain echo) surfaces this
+          # as a yellow annotation on the workflow run summary page, not just
+          # buried in step logs. During the 0.1.1 release we shipped three
+          # green workflow runs in a row where publish was silently skipping
+          # because the secret had been added to the wrong scope; a loud
+          # annotation would have caught that in seconds. See issue #3 for
+          # the longer-term fix (migrating to OIDC trusted publishing, which
+          # removes the need for this guard entirely).
           if [ -n "${TEST_PYPI_API_TOKEN:-}" ]; then
             echo "have_token=true" >> "$GITHUB_OUTPUT"
           else
             echo "have_token=false" >> "$GITHUB_OUTPUT"
-            echo "TEST_PYPI_API_TOKEN not set; skipping TestPyPI publish."
+            echo "::warning title=TestPyPI publish skipped::TEST_PYPI_API_TOKEN secret is not set on this repository, so the TestPyPI upload was skipped. The workflow is not failing because forks and test-tag pushes intentionally tolerate missing secrets, but if you expected this tag to publish, add the secret under Settings > Secrets and variables > Actions (https://github.com/${{ github.repository }}/settings/secrets/actions) and re-run this workflow. See issue #3 for the OIDC migration that removes this class of mistake."
           fi
 
       - uses: actions/download-artifact@v4
@@ -240,11 +248,16 @@ jobs:
         env:
           PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
+          # See the matching note on the TestPyPI job above. A missing token
+          # here is the more serious case of the two — a silent skip means
+          # a tagged release that looks published in GitHub is not actually
+          # on PyPI. The annotation makes that state impossible to miss on
+          # the run summary page.
           if [ -n "${PYPI_API_TOKEN:-}" ]; then
             echo "have_token=true" >> "$GITHUB_OUTPUT"
           else
             echo "have_token=false" >> "$GITHUB_OUTPUT"
-            echo "PYPI_API_TOKEN not set; skipping PyPI publish."
+            echo "::warning title=PyPI publish skipped::PYPI_API_TOKEN secret is not set on this repository, so the PyPI upload was skipped. The workflow is not failing because forks and test-tag pushes intentionally tolerate missing secrets, but if you expected this tag to publish to PyPI, add the secret under Settings > Secrets and variables > Actions (https://github.com/${{ github.repository }}/settings/secrets/actions) and re-run this workflow. See issue #3 for the OIDC migration that removes this class of mistake."
           fi
 
       - uses: actions/download-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing
+
+## Releases
+
+Releases are cut by pushing a `v<version>` tag that matches the `version`
+field in `pyproject.toml`. The `Release` workflow
+(`.github/workflows/release.yml`) then runs the full test matrix, builds
+sdist + wheel, attaches them to a GitHub Release, and (optionally)
+uploads to TestPyPI and PyPI.
+
+### Required repository secrets
+
+Two Actions secrets gate the PyPI uploads. They are **optional** in the
+sense that the workflow is designed not to fail when they are absent
+(so forks and test-tag pushes stay green), but if you want a tag to
+actually reach PyPI, both must be set:
+
+| Secret name           | Where to get it                         | Used by                   |
+| --------------------- | --------------------------------------- | ------------------------- |
+| `TEST_PYPI_API_TOKEN` | <https://test.pypi.org/manage/account/> | `testpypi-publish` job    |
+| `PYPI_API_TOKEN`      | <https://pypi.org/manage/account/>      | `pypi-publish` job        |
+
+Add them under **Settings → Secrets and variables → Actions → Repository
+secrets**. The `gh` CLI equivalent (from a clone of this repo):
+
+```bash
+gh secret set TEST_PYPI_API_TOKEN --repo dingxianzhong/inventory-pricing
+gh secret set PYPI_API_TOKEN      --repo dingxianzhong/inventory-pricing
+```
+
+Note: the secrets live under the **Actions** scope specifically — not
+Dependabot secrets, not Codespaces secrets, and not Variables. An
+easy-to-make mistake is putting them in the wrong tab; if that happens,
+the publish jobs will silently skip (see below).
+
+### What a missing-secret run looks like
+
+If either token is absent when a `v*` tag is pushed, the corresponding
+publish job still reports success (by design) but emits a workflow
+annotation at the top of the run summary page:
+
+> ⚠️ **PyPI publish skipped** — `PYPI_API_TOKEN` secret is not set on
+> this repository, so the PyPI upload was skipped. …
+
+The annotation is yellow, appears above the job graph, and links back
+to the repo's secrets page. If you tagged a release expecting it to
+publish and you see one of these annotations instead, the fix is to
+add the missing secret and re-run the workflow (`gh run rerun <id>`) —
+no re-tagging needed.
+
+This warning exists because we shipped the 0.1.1 release with three
+successive green workflow runs that were all silently skipping
+publish; the annotation makes that state impossible to miss on the
+next round. The longer-term fix is migrating to PyPI trusted
+publishing (OIDC), tracked in issue #3, which removes the need for
+long-lived tokens entirely.


### PR DESCRIPTION
## Summary

Minimal safety-net for the silent-skip failure mode we hit during the 0.1.1 release (three successive green workflow runs with publish skipped because secrets were in the wrong scope).

## Changes

- `.github/workflows/release.yml`: the token-guard steps in both `testpypi-publish` and `pypi-publish` now emit `::warning title=...::...` workflow commands instead of a plain `echo` when their secret is missing. This surfaces as a yellow annotation on the run summary page with a direct link to the repo's secrets settings and a pointer to #3.
- `CONTRIBUTING.md` (new): short `Releases` section documenting the two required secret names, how to set them (UI and `gh` CLI), the common 'wrong tab' mistake, and what the warning annotation looks like / how to recover.

## What is deliberately **not** changed

- The skip-on-missing-secret behavior itself is preserved. Forks and test-tag pushes that don't have secrets continue to pass, not fail. That tolerance is the reason the guard exists; this PR is only about making the skip visible when it happens on the main repo.
- The skip uses `::warning::`, not `::error::`. An error would fail the job and defeat the fork-tolerance above. Warnings are the right severity for 'this succeeded but you should probably notice.'

## Follow-up

Issue #3 (OIDC trusted publishing) removes this whole class of bug by eliminating the long-lived tokens entirely. This PR is the stop-gap until that lands.

## Test plan

YAML parses (`python -c 'import yaml; yaml.safe_load(...)'`). Test suite still 39/39 green locally. CI on this branch exercises the full workflow matrix; the warning path itself is only triggered on `push` tags `v*`, which CI does not simulate — it will get its first real-world exercise on the next release tag, which is fine for a safety-net.