### PR TITLE
Migrate release workflow to PyPI Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,51 +171,47 @@ jobs:
           fail_on_unmatched_files: true
 
   # ---------------------------------------------------------------------------
-  # 4. Optional TestPyPI publish. Runs before the real PyPI step so we can
-  #    catch metadata / upload issues on the staging index first. Gated on
-  #    TEST_PYPI_API_TOKEN; absent secret ⇒ job is a no-op (doesn't fail).
+  # 4. Publish to TestPyPI via PyPI Trusted Publishing (OIDC). Runs before the
+  #    real PyPI step so metadata / upload issues surface on the staging
+  #    index first.
+  #
+  #    Auth model: no long-lived API token. `id-token: write` lets the job
+  #    mint a short-lived OIDC credential per run; TestPyPI validates it
+  #    against the (owner, repo, workflow filename, environment) tuple
+  #    pre-registered on test.pypi.org. See CONTRIBUTING.md → Releases for
+  #    the one-time setup.
+  #
+  #    Fork safety: forks cannot mint an OIDC token for this repo, and the
+  #    `environment: testpypi` below is only defined on the upstream repo,
+  #    so fork runs of this workflow will simply skip/fail-closed on this
+  #    job without leaking anything. The `if:` guard makes the skip explicit
+  #    and keeps fork runs green.
   #
   #    Note: TestPyPI treats filename reuse the same as PyPI — you can't
-  #    re-upload the same version. `skip-existing: true` is intentional here
-  #    so re-running the workflow on the same tag (e.g. to retry the real
+  #    re-upload the same version. `skip-existing: true` is intentional so
+  #    re-running the workflow on the same tag (e.g. to retry the real
   #    PyPI publish) doesn't error out on the TestPyPI side.
   # ---------------------------------------------------------------------------
   testpypi-publish:
-    name: Publish to TestPyPI (optional)
+    name: Publish to TestPyPI
     needs: build
     runs-on: ubuntu-latest
+    if: github.repository == 'dingxianzhong/inventory-pricing'
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/inventory-pricing/
+    permissions:
+      id-token: write   # required for OIDC trusted publishing
+      contents: read
     steps:
-      - name: Check for TEST_PYPI_API_TOKEN
-        id: check
-        env:
-          TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        run: |
-          # Emitting `::warning::` (rather than a plain echo) surfaces this
-          # as a yellow annotation on the workflow run summary page, not just
-          # buried in step logs. During the 0.1.1 release we shipped three
-          # green workflow runs in a row where publish was silently skipping
-          # because the secret had been added to the wrong scope; a loud
-          # annotation would have caught that in seconds. See issue #3 for
-          # the longer-term fix (migrating to OIDC trusted publishing, which
-          # removes the need for this guard entirely).
-          if [ -n "${TEST_PYPI_API_TOKEN:-}" ]; then
-            echo "have_token=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "have_token=false" >> "$GITHUB_OUTPUT"
-            echo "::warning title=TestPyPI publish skipped::TEST_PYPI_API_TOKEN secret is not set on this repository, so the TestPyPI upload was skipped. The workflow is not failing because forks and test-tag pushes intentionally tolerate missing secrets, but if you expected this tag to publish, add the secret under Settings > Secrets and variables > Actions (https://github.com/${{ github.repository }}/settings/secrets/actions) and re-run this workflow. See issue #3 for the OIDC migration that removes this class of mistake."
-          fi
-
       - uses: actions/download-artifact@v4
-        if: steps.check.outputs.have_token == 'true'
         with:
           name: dist
           path: dist
 
       - name: Publish to TestPyPI
-        if: steps.check.outputs.have_token == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist
           # Allow retries on the same tag without failing the TestPyPI
@@ -224,53 +220,35 @@ jobs:
           skip-existing: true
 
   # ---------------------------------------------------------------------------
-  # 5. Optional PyPI publish. Runs only if PYPI_API_TOKEN is configured at the
-  #    repo/org level. If the secret is absent the job is skipped, so forks
-  #    and test releases (e.g. v0.0.0-rc1 on a fork without the secret) don't
-  #    error out.
+  # 5. Publish to PyPI via PyPI Trusted Publishing (OIDC).
   #
-  #    Depends on testpypi-publish so, when both tokens are configured, the
-  #    staging upload happens first and a broken upload fails the pipeline
-  #    before it touches real PyPI. When TEST_PYPI_API_TOKEN isn't set,
-  #    testpypi-publish no-ops and this job still runs.
+  #    Depends on testpypi-publish so the staging upload happens first and
+  #    a broken upload fails the pipeline before it touches real PyPI.
   #
-  #    NOTE: OIDC "trusted publishing" (pypa/gh-action-pypi-publish without a
-  #    token, configured on PyPI side) is the modern alternative and avoids
-  #    long-lived tokens entirely. Kept token-based here per request.
+  #    Same auth/fork-safety model as the TestPyPI job above: no long-lived
+  #    token; the `environment: pypi` is pre-registered on pypi.org against
+  #    this repo + this workflow filename.
   # ---------------------------------------------------------------------------
   pypi-publish:
-    name: Publish to PyPI (optional)
+    name: Publish to PyPI
     needs: [build, testpypi-publish]
     runs-on: ubuntu-latest
+    if: github.repository == 'dingxianzhong/inventory-pricing'
+    environment:
+      name: pypi
+      url: https://pypi.org/project/inventory-pricing/
+    permissions:
+      id-token: write   # required for OIDC trusted publishing
+      contents: read
     steps:
-      - name: Check for PYPI_API_TOKEN
-        id: check
-        env:
-          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          # See the matching note on the TestPyPI job above. A missing token
-          # here is the more serious case of the two — a silent skip means
-          # a tagged release that looks published in GitHub is not actually
-          # on PyPI. The annotation makes that state impossible to miss on
-          # the run summary page.
-          if [ -n "${PYPI_API_TOKEN:-}" ]; then
-            echo "have_token=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "have_token=false" >> "$GITHUB_OUTPUT"
-            echo "::warning title=PyPI publish skipped::PYPI_API_TOKEN secret is not set on this repository, so the PyPI upload was skipped. The workflow is not failing because forks and test-tag pushes intentionally tolerate missing secrets, but if you expected this tag to publish to PyPI, add the secret under Settings > Secrets and variables > Actions (https://github.com/${{ github.repository }}/settings/secrets/actions) and re-run this workflow. See issue #3 for the OIDC migration that removes this class of mistake."
-          fi
-
       - uses: actions/download-artifact@v4
-        if: steps.check.outputs.have_token == 'true'
         with:
           name: dist
           path: dist
 
       - name: Publish to PyPI
-        if: steps.check.outputs.have_token == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: dist
           # Fail loudly if a version is already on PyPI rather than silently
           # skipping — a duplicate upload almost always means a mis-tagged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,52 +5,71 @@
 Releases are cut by pushing a `v<version>` tag that matches the `version`
 field in `pyproject.toml`. The `Release` workflow
 (`.github/workflows/release.yml`) then runs the full test matrix, builds
-sdist + wheel, attaches them to a GitHub Release, and (optionally)
-uploads to TestPyPI and PyPI.
+sdist + wheel, attaches them to a GitHub Release, and uploads to
+TestPyPI and PyPI.
 
-### Required repository secrets
+### Authentication: PyPI Trusted Publishing (OIDC)
 
-Two Actions secrets gate the PyPI uploads. They are **optional** in the
-sense that the workflow is designed not to fail when they are absent
-(so forks and test-tag pushes stay green), but if you want a tag to
-actually reach PyPI, both must be set:
+Uploads authenticate to PyPI and TestPyPI via
+[Trusted Publishing][tp] — no long-lived API token is stored in the
+repo. Each workflow run mints a short-lived OIDC credential that PyPI
+validates against a pre-registered tuple of (GitHub owner, repo,
+workflow filename, environment).
 
-| Secret name           | Where to get it                         | Used by                   |
-| --------------------- | --------------------------------------- | ------------------------- |
-| `TEST_PYPI_API_TOKEN` | <https://test.pypi.org/manage/account/> | `testpypi-publish` job    |
-| `PYPI_API_TOKEN`      | <https://pypi.org/manage/account/>      | `pypi-publish` job        |
+[tp]: https://docs.pypi.org/trusted-publishers/
 
-Add them under **Settings → Secrets and variables → Actions → Repository
-secrets**. The `gh` CLI equivalent (from a clone of this repo):
+This means:
 
-```bash
-gh secret set TEST_PYPI_API_TOKEN --repo dingxianzhong/inventory-pricing
-gh secret set PYPI_API_TOKEN      --repo dingxianzhong/inventory-pricing
-```
+- No token to rotate, leak, or forget to add. The 0.1.1-era failure
+  mode of "secret silently missing from Actions scope → publish skips
+  → tagged release never reaches PyPI" is structurally impossible —
+  misconfiguration makes the job **fail**, not silently skip.
+- Forks cannot publish. OIDC credentials are bound to the upstream
+  `dingxianzhong/inventory-pricing` repo, and the workflow is
+  additionally guarded with
+  `if: github.repository == 'dingxianzhong/inventory-pricing'` on
+  both publish jobs.
 
-Note: the secrets live under the **Actions** scope specifically — not
-Dependabot secrets, not Codespaces secrets, and not Variables. An
-easy-to-make mistake is putting them in the wrong tab; if that happens,
-the publish jobs will silently skip (see below).
+### One-time setup on PyPI / TestPyPI
 
-### What a missing-secret run looks like
+If you're standing this up on a fresh repo (or re-registering after a
+rename), configure each index once via the web UI:
 
-If either token is absent when a `v*` tag is pushed, the corresponding
-publish job still reports success (by design) but emits a workflow
-annotation at the top of the run summary page:
+**PyPI** — <https://pypi.org/manage/project/inventory-pricing/settings/publishing/>
 
-> ⚠️ **PyPI publish skipped** — `PYPI_API_TOKEN` secret is not set on
-> this repository, so the PyPI upload was skipped. …
+- PyPI Project Name: `inventory-pricing`
+- Owner: `dingxianzhong`
+- Repository name: `inventory-pricing`
+- Workflow filename: `release.yml`
+- Environment name: `pypi`
 
-The annotation is yellow, appears above the job graph, and links back
-to the repo's secrets page. If you tagged a release expecting it to
-publish and you see one of these annotations instead, the fix is to
-add the missing secret and re-run the workflow (`gh run rerun <id>`) —
-no re-tagging needed.
+**TestPyPI** — <https://test.pypi.org/manage/project/inventory-pricing/settings/publishing/>
 
-This warning exists because we shipped the 0.1.1 release with three
-successive green workflow runs that were all silently skipping
-publish; the annotation makes that state impossible to miss on the
-next round. The longer-term fix is migrating to PyPI trusted
-publishing (OIDC), tracked in issue #3, which removes the need for
-long-lived tokens entirely.
+- Same four fields, except Environment name: `testpypi`
+
+(For a project that doesn't exist on (Test)PyPI yet, use the "pending
+publisher" flow under the account's Publishing tab instead — it
+pre-authorizes the first upload to create the project.)
+
+On the GitHub side, create the two environments under **Settings →
+Environments**:
+
+- `pypi`
+- `testpypi`
+
+Environments may be left with default settings; they exist so the OIDC
+binding has something concrete to reference. Optional hardening:
+protection rules (required reviewers, tag pattern restriction to
+`v*`) can be added to either environment without changing the
+workflow.
+
+### What a misconfigured run looks like
+
+Unlike the previous token-based flow, a missing or misconfigured
+publisher registration causes the publish job to **fail**, not
+silently succeed. The failing step is the
+`pypa/gh-action-pypi-publish` action itself, and its error message
+names the mismatched field (wrong workflow filename, wrong
+environment, unregistered repo, etc.). Fix the registration on the
+PyPI side and re-run the workflow with `gh run rerun <id>` — no
+re-tagging needed.


### PR DESCRIPTION
Migrates both publish jobs in `release.yml` from long-lived API tokens to
[PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) via
GitHub Actions OIDC. Closes #3 once the PyPI-side registration below is
done.

## What changed

### `.github/workflows/release.yml`
- `testpypi-publish` and `pypi-publish`:
  - Added `permissions: id-token: write` (+ explicit `contents: read`).
  - Added `environment:` blocks (`testpypi` and `pypi`) so the OIDC claim
    has a concrete scope to match against the trusted-publisher
    registration.
  - Removed the `password:` input from `pypa/gh-action-pypi-publish` — it
    now uses OIDC automatically.
  - Removed the `Check for *_API_TOKEN` guard steps and the
    `::warning::` annotations added in #5. With OIDC, a misconfigured
    publisher fails the publish step loudly, so the silent-skip failure
    mode those annotations existed to catch is no longer reachable.
  - Fork safety preserved via
    `if: github.repository == 'dingxianzhong/inventory-pricing'`.
- Job graph and `skip-existing` semantics unchanged
  (test → build → { github-release, testpypi-publish → pypi-publish };
  TestPyPI `skip-existing: true`, PyPI `skip-existing: false`).

### `CONTRIBUTING.md`
- Rewrote the Releases section: OIDC overview, one-time PyPI/TestPyPI
  registration steps with exact field values, GitHub-environment setup,
  and a new "misconfigured run" subsection describing what failure
  looks like (a failed publish step, not a silent skip).

## Deliberately **not** done in this PR

- **Existing secrets `PYPI_API_TOKEN` / `TEST_PYPI_API_TOKEN` are left
  in place.** They become no-ops once this merges (nothing reads them),
  but we keep them until a TestPyPI pre-release verifies the OIDC path
  works end-to-end. Removal is a one-liner follow-up after that.

## Checklist — things **you** need to do before merging / releasing

### 1. Create GitHub environments (repo side, ~30 seconds)
On <https://github.com/dingxianzhong/inventory-pricing/settings/environments>:
- [ ] Create environment named exactly `pypi` (no protection rules needed yet).
- [ ] Create environment named exactly `testpypi`.

### 2. Register trusted publisher on **TestPyPI**
On <https://test.pypi.org/manage/project/inventory-pricing/settings/publishing/>
(if the project already exists on TestPyPI) or the account-level
"pending publisher" flow (if it doesn't):
- [ ] PyPI Project Name: `inventory-pricing`
- [ ] Owner: `dingxianzhong`
- [ ] Repository name: `inventory-pricing`
- [ ] Workflow filename: `release.yml`
- [ ] Environment name: `testpypi`

### 3. Register trusted publisher on **PyPI**
On <https://pypi.org/manage/project/inventory-pricing/settings/publishing/>:
- [ ] Same four fields as above, except Environment name: `pypi`

### 4. Verify end-to-end on TestPyPI **before** merging-and-relying
- [ ] After this PR is merged, bump to a pre-release version
      (e.g. `0.1.2rc1`) on a short-lived branch, push tag `v0.1.2rc1`,
      and confirm:
  - `testpypi-publish` job succeeds (green, no warning annotation).
  - Package appears at
    <https://test.pypi.org/project/inventory-pricing/0.1.2rc1/>.
  - `pypi-publish` succeeds too (or, if you want to isolate the
    TestPyPI test, temporarily skip by not pushing the final tag).

### 5. Follow-up (separate tiny PR, after step 4 is green)
- [ ] Delete `PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN` from
      <https://github.com/dingxianzhong/inventory-pricing/settings/secrets/actions>
- [ ] Close issue #3.

## CI expectations for this PR

Only the `test` job runs on PRs (the publish jobs are tag-gated). So CI
here is just the 12-cell matrix re-green; no publish attempt happens
until a `v*` tag is pushed post-merge.
