### PR TITLE
test: property-based tests and zero-preservation regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
       - name: Install package + test deps
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .
-          python -m pip install pytest
+          python -m pip install -e .[test]
 
       - name: Run pytest
         run: python -m pytest tests/ -v

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -18,6 +18,19 @@ class Product:
 
 @dataclass
 class Warehouse:
+    """A named inventory container tracking per-SKU quantities.
+
+    Note on zero-quantity SKUs:
+        ``add(sku, 0)`` creates a ``stock`` entry with value 0 for a new
+        SKU. ``remove(sku, qty)`` with ``qty > 0`` decrements the count
+        down to zero and leaves the SKU in ``stock`` with value ``0``.
+        This "present at 0" state is distinguishable from "absent SKU"
+        and is observable via ``monthly_report`` and
+        ``stock_alert(threshold=0)``. Whether to collapse the two states
+        is tracked as a design decision in issue #21:
+        https://github.com/dingxianzhong/inventory-pricing/issues/21
+    """
+
     name: str
     stock: dict[str, int] = field(default_factory=dict)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,15 @@ Repository = "https://github.com/dingxianzhong/inventory-pricing"
 Changelog = "https://github.com/dingxianzhong/inventory-pricing/blob/main/CHANGELOG.md"
 Issues = "https://github.com/dingxianzhong/inventory-pricing/issues"
 
+[project.optional-dependencies]
+# Dependencies needed to run the test suite. CI installs the package
+# with `pip install -e .[test]`. Kept separate from any future `dev`
+# extra so CI doesn't pull in linters/type-checkers it doesn't need.
+test = [
+    "pytest",
+    "hypothesis",
+]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["inventory*"]

--- a/tests/test_models_properties.py
+++ b/tests/test_models_properties.py
@@ -1,0 +1,98 @@
+"""Property-based tests for inventory.models.
+
+Tracked in GitHub issue #18.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+
+from hypothesis import given, strategies as st
+
+from inventory.models import Warehouse
+
+
+# --- Strategies ------------------------------------------------------------
+
+# Small SKU alphabet so the generated SKU often collides with the initial
+# stock keys (exercising the "existing SKU" case), but also sometimes
+# doesn't (exercising the "new SKU" case).
+sku_strategy = st.text(
+    alphabet=st.characters(min_codepoint=65, max_codepoint=70),  # A-F
+    min_size=1,
+    max_size=2,
+)
+
+# Non-negative integer quantities. Includes 0 so the no-op/identity case
+# is exercised.
+qty_strategy = st.integers(min_value=0, max_value=1_000)
+
+# Initial stock: a dict[sku, non-negative int]. May be empty.
+stock_strategy = st.dictionaries(
+    keys=sku_strategy,
+    values=qty_strategy,
+    max_size=5,
+)
+
+
+# --- Properties ------------------------------------------------------------
+
+@st.composite
+def stock_and_existing_sku(draw):
+    """Draw a non-empty stock dict and a SKU that is guaranteed to be one
+    of its existing keys. Lets us state a clean identity property for the
+    "existing SKU" case.
+    """
+    stock = draw(stock_strategy.filter(lambda s: len(s) > 0))
+    sku = draw(st.sampled_from(sorted(stock)))
+    return stock, sku
+
+
+@given(pair=stock_and_existing_sku(), qty=qty_strategy)
+def test_add_then_remove_is_identity_for_existing_sku(pair, qty):
+    """For any starting stock, any SKU **already present** in that stock,
+    and any qty >= 0:
+
+    1. ``add(sku, qty)`` then ``remove(sku, qty)`` leaves the stock exactly
+       equal to the initial stock.
+    2. ``remove`` returns ``True``.
+
+    Covers qty=0 (pure no-op) and qty>0 (round-trip) on existing SKUs.
+    """
+    initial_stock, sku = pair
+    # Warehouse mutates its own dict in place, so snapshot the expected
+    # value from a deep copy before handing another copy to the Warehouse.
+    expected = deepcopy(initial_stock)
+    w = Warehouse(name="w", stock=deepcopy(initial_stock))
+
+    w.add(sku, qty)
+    removed_ok = w.remove(sku, qty)
+
+    assert removed_ok is True
+    assert w.stock == expected
+
+
+@given(initial_stock=stock_strategy, sku=sku_strategy, qty=qty_strategy)
+def test_add_then_remove_preserves_effective_stock(initial_stock, sku, qty):
+    """Weaker "effective stock" property that holds for ANY SKU (existing
+    or new): after ``add(sku, qty)`` + ``remove(sku, qty)``, the stock
+    agrees with the initial stock on every SKU's quantity, treating a
+    missing SKU as 0. ``remove`` always returns ``True``.
+
+    This is the honest statement of the round-trip invariant on the
+    current API: ``remove`` does not delete a SKU when its count hits 0,
+    so a brand-new SKU passed to ``add(sku, n)`` + ``remove(sku, n)`` is
+    left behind as ``{sku: 0}``. Quantities are unchanged in every
+    observable sense (``available(sku) == initial_stock.get(sku, 0)``).
+    """
+    w = Warehouse(name="w", stock=deepcopy(initial_stock))
+
+    w.add(sku, qty)
+    removed_ok = w.remove(sku, qty)
+
+    assert removed_ok is True
+    # Every SKU that was in initial_stock retains its original quantity.
+    for k, v in initial_stock.items():
+        assert w.available(k) == v
+    # The possibly-newly-introduced SKU is observable as 0 (i.e. absent
+    # for all practical purposes).
+    assert w.available(sku) == initial_stock.get(sku, 0)

--- a/tests/test_pricing_properties.py
+++ b/tests/test_pricing_properties.py
@@ -1,0 +1,121 @@
+"""Property-based tests for inventory.pricing.
+
+Tracked in GitHub issues #15 (compute_total linearity) and #17
+(apply_discount monotonicity).
+"""
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, strategies as st
+
+from inventory.models import Order, Product
+from inventory.pricing import apply_discount, compute_total
+
+
+# --- Strategies ------------------------------------------------------------
+
+# SKU: short non-empty ASCII identifier. Kept small so duplicates across
+# items are likely (which is part of what we want to exercise).
+sku_strategy = st.text(
+    alphabet=st.characters(min_codepoint=65, max_codepoint=90),  # A-Z
+    min_size=1,
+    max_size=3,
+)
+
+# Prices: finite, non-negative, bounded so that price * qty * len(items)
+# stays well away from float overflow.
+price_strategy = st.floats(
+    min_value=0.0,
+    max_value=1_000_000.0,
+    allow_nan=False,
+    allow_infinity=False,
+)
+
+# Quantities: non-negative, bounded.
+qty_strategy = st.integers(min_value=0, max_value=1_000)
+
+# Discount percentages: finite, in [0, 100].
+discount_strategy = st.floats(
+    min_value=0.0,
+    max_value=100.0,
+    allow_nan=False,
+    allow_infinity=False,
+)
+
+
+@st.composite
+def catalog_and_order(draw):
+    """Draw a catalog (dict[sku, Product]) and an Order whose items' SKUs
+    are all drawn from the catalog. Duplicate SKUs in items are allowed.
+    """
+    # Non-empty catalog so we can always pick at least one SKU.
+    skus = draw(st.lists(sku_strategy, min_size=1, max_size=5, unique=True))
+    catalog = {
+        sku: Product(sku=sku, name=sku, unit_price=draw(price_strategy))
+        for sku in skus
+    }
+
+    # Order items: each picks a SKU from the catalog (duplicates allowed)
+    # paired with a non-negative qty. Empty orders are valid too.
+    items = draw(
+        st.lists(
+            st.tuples(st.sampled_from(skus), qty_strategy),
+            min_size=0,
+            max_size=20,
+        )
+    )
+    order = Order(order_id="o", items=items)
+    return catalog, order
+
+
+# --- Property --------------------------------------------------------------
+
+@given(catalog_and_order())
+def test_compute_total_is_linear_when_discount_is_zero(pair):
+    """compute_total(order, catalog, discount_pct=0) ==
+    sum(catalog[sku].unit_price * qty for sku, qty in order.items).
+
+    Holds for any catalog + order whose SKUs are all in the catalog, with
+    duplicate SKUs allowed and quantities possibly zero.
+    """
+    catalog, order = pair
+    expected = sum(
+        catalog[sku].unit_price * qty for sku, qty in order.items
+    )
+    assert compute_total(order, catalog, discount_pct=0.0) == pytest.approx(
+        expected
+    )
+
+
+@given(
+    price=price_strategy,
+    discounts=st.tuples(discount_strategy, discount_strategy),
+)
+def test_apply_discount_is_monotonic_in_discount_pct(price, discounts):
+    """For any finite non-negative price and any d1 <= d2 in [0, 100]:
+
+    - apply_discount(price, d1) >= apply_discount(price, d2)
+    - the result is always in [0, price]
+    """
+    d1, d2 = sorted(discounts)
+
+    p1 = apply_discount(price, d1)
+    p2 = apply_discount(price, d2)
+
+    # Monotonic: a larger discount yields a smaller-or-equal price.
+    # Use a tiny absolute tolerance to absorb float rounding on equal inputs.
+    assert p1 + 1e-9 >= p2
+
+    # Bounded: result stays in [0, price] (again with a small tolerance
+    # for floating-point noise at the endpoints).
+    assert p1 >= -1e-9
+    assert p2 >= -1e-9
+    assert p1 <= price + 1e-9
+    assert p2 <= price + 1e-9
+
+
+@given(price=price_strategy)
+def test_apply_discount_endpoint_identities(price):
+    """d=0 returns the price unchanged; d=100 returns 0."""
+    assert apply_discount(price, 0.0) == pytest.approx(price)
+    assert apply_discount(price, 100.0) == pytest.approx(0.0)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -41,3 +41,50 @@ def test_monthly_report_multiple_warehouses():
     w2 = Warehouse(name="overflow", stock={"A": 2, "C": 7})
     report = monthly_report([w1, w2])
     assert report == {"A": 7, "B": 3, "C": 7}
+
+
+# --- Zero-quantity SKU preservation (regression for #14) ------------------
+
+def test_monthly_report_single_warehouse_preserves_zero_sku():
+    """A SKU with stock 0 in a single warehouse must still appear in the
+    aggregate report with value 0 (not dropped).
+    """
+    w = Warehouse(name="main", stock={"A": 0})
+    report = monthly_report([w])
+    assert report == {"A": 0}
+    assert "A" in report
+
+
+def test_monthly_report_split_preserves_zero_sku_from_one_side():
+    """When one partition has no entry for a SKU and the other has it at
+    qty 0, the aggregate across both must still include that SKU at 0.
+    This is the split case that exposed a bug in the property-test helper
+    (Counter.__add__ drops zero counts); monthly_report itself must keep
+    it.
+    """
+    left = Warehouse(name="left", stock={"B": 5})       # no "A"
+    right = Warehouse(name="right", stock={"A": 0})     # "A" at zero
+    report = monthly_report([left, right])
+    assert report == {"A": 0, "B": 5}
+    assert "A" in report
+
+
+def test_monthly_report_multiple_zero_contributions_sum_to_zero():
+    """Two warehouses each contributing 0 for the same SKU should still
+    leave that SKU in the aggregate at 0 (not filter it out).
+    """
+    w1 = Warehouse(name="w1", stock={"A": 0})
+    w2 = Warehouse(name="w2", stock={"A": 0})
+    report = monthly_report([w1, w2])
+    assert report == {"A": 0}
+    assert "A" in report
+
+
+def test_monthly_report_mixed_zero_and_positive_for_same_sku():
+    """Zero in one warehouse plus a positive value in another should sum
+    normally; zero must not be treated as 'absent'.
+    """
+    w1 = Warehouse(name="w1", stock={"A": 0, "B": 4})
+    w2 = Warehouse(name="w2", stock={"A": 3})
+    report = monthly_report([w1, w2])
+    assert report == {"A": 3, "B": 4}

--- a/tests/test_reports_properties.py
+++ b/tests/test_reports_properties.py
@@ -1,0 +1,82 @@
+"""Property-based tests for inventory.reports.
+
+Tracked in GitHub issue #16.
+"""
+from __future__ import annotations
+
+from hypothesis import given, strategies as st
+
+from inventory.models import Warehouse
+from inventory.reports import monthly_report
+
+
+# --- Strategies ------------------------------------------------------------
+
+# Small SKU alphabet so warehouses are likely to share SKUs (that's what
+# makes aggregation interesting — pure disjoint stock would be a weaker
+# test of distributivity).
+sku_strategy = st.text(
+    alphabet=st.characters(min_codepoint=65, max_codepoint=70),  # A-F
+    min_size=1,
+    max_size=2,
+)
+
+# Non-negative integer stock. Bounded so generated lists stay small.
+qty_strategy = st.integers(min_value=0, max_value=1_000)
+
+stock_strategy = st.dictionaries(
+    keys=sku_strategy,
+    values=qty_strategy,
+    max_size=5,
+)
+
+
+@st.composite
+def warehouse_strategy(draw):
+    # Warehouse.name doesn't affect monthly_report, so just use an index-y
+    # label to aid shrinking readability.
+    stock = draw(stock_strategy)
+    return Warehouse(name="w", stock=stock)
+
+
+warehouses_strategy = st.lists(warehouse_strategy(), min_size=0, max_size=5)
+
+
+# --- Helper ----------------------------------------------------------------
+
+def _pointwise_sum(a: dict[str, int], b: dict[str, int]) -> dict[str, int]:
+    """Per-key sum of two SKU totals dicts, preserving ALL keys including
+    those whose combined value is 0. Unlike ``Counter.__add__``, this does
+    not drop non-positive totals — matching ``monthly_report``'s behavior.
+    """
+    result: dict[str, int] = dict(a)
+    for sku, qty in b.items():
+        result[sku] = result.get(sku, 0) + qty
+    return result
+
+
+# --- Properties ------------------------------------------------------------
+
+@given(data=st.data())
+def test_monthly_report_distributes_over_partitions(data):
+    """For any list of warehouses `ws` and any index `i` in [0, len(ws)],
+    monthly_report(ws) == pointwise_sum(
+        monthly_report(ws[:i]), monthly_report(ws[i:])
+    ).
+    """
+    ws = data.draw(warehouses_strategy, label="warehouses")
+    i = data.draw(st.integers(min_value=0, max_value=len(ws)), label="split")
+
+    left = monthly_report(ws[:i])
+    right = monthly_report(ws[i:])
+    combined = monthly_report(ws)
+
+    assert combined == _pointwise_sum(left, right)
+
+
+@given(warehouses_strategy)
+def test_monthly_report_is_order_independent(ws):
+    """monthly_report must not depend on the order of warehouses in the
+    input list (aggregation is commutative).
+    """
+    assert monthly_report(ws) == monthly_report(list(reversed(ws)))


### PR DESCRIPTION
## Summary

Adds Hypothesis-based property tests and targeted regression coverage
for the `inventory` package, plus a `Warehouse` docstring documenting
observable behavior around zero-count stock entries. Strictly additive
— no production code behavior changes.

## Added

- **`pyproject.toml`**: new `[project.optional-dependencies].test` extra
  containing `pytest` and `hypothesis`.
- **`.github/workflows/ci.yml`**: install via `pip install -e .[test]`
  instead of a separate `pip install pytest` step.
- **`tests/test_reports.py`**: four regression tests pinning that
  `monthly_report` retains SKUs whose aggregate quantity is `0`
  (single warehouse, asymmetric split, multiple zero contributions,
  and zero mixed with positive).
- **`tests/test_reports_properties.py`** *(new)*: Hypothesis properties
  for `monthly_report` distributivity over any partition and for
  order-independence.
- **`tests/test_pricing_properties.py`** *(new)*: Hypothesis properties
  for `compute_total` linearity at `discount_pct=0`, `apply_discount`
  monotonicity on `[0, 100]`, and endpoint identities (`d=0 → price`,
  `d=100 → 0`).
- **`tests/test_models_properties.py`** *(new)*: Hypothesis properties
  for `Warehouse.add` + `remove` round-trip (strict dict-identity for
  existing SKUs; weaker "effective stock" invariant for any SKU).
- **`inventory/models.py`**: class docstring on `Warehouse` describing
  the "present at 0" vs. "absent" distinction observable via
  `monthly_report` and `stock_alert(threshold=0)`, with a link to #21.
  Pure docs; no behavior change.

Closes #14, #15, #16, #17, #18.
References #21.
