### PR TITLE
chore(ci): add ruff + flake8 lint extra, pre-commit config, and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,26 @@ jobs:
 
       - name: Run pytest
         run: python -m pytest tests/ -v
+
+  lint:
+    name: lint (ruff + flake8)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install lint tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[lint]
+
+      - name: ruff
+        run: ruff check inventory tests
+
+      - name: flake8
+        run: flake8 inventory tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# Versions below are pinned exactly. They MUST be kept in sync with the
+# `lint` extra in pyproject.toml — CI installs linters from the extra
+# while developers run them via pre-commit, and the two paths need to
+# agree or the build will fail on "clean" commits. If you bump one,
+# bump the other in the same commit.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.7
+    hooks:
+      - id: ruff
+        args: [--fix]
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,53 @@
 # Contributing
 
+## Development setup
+
+Clone the repo and install it in editable mode with the `test` and
+`lint` extras:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[test,lint]
+```
+
+### Running tests
+
+```bash
+pytest -v
+```
+
+### Linting
+
+Two tools run on every commit (via pre-commit) and in CI:
+
+- `ruff` — configured via `[tool.ruff]` in `pyproject.toml`
+  (defaults + isort). Run locally with `ruff check inventory tests`
+  or with `--fix` to auto-apply safe fixes.
+- `flake8` — the classic pycodestyle/pyflakes linter.
+  Run locally with `flake8 inventory tests`.
+
+Tool versions are pinned in two places that must be kept in sync: the
+`lint` extra in `pyproject.toml` (used by CI) and the `rev:` fields in
+`.pre-commit-config.yaml` (used by developers locally). Bump them
+together in the same commit.
+
+### Pre-commit hooks
+
+Install the hooks once per clone so ruff/flake8 run on every commit
+automatically:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Run all hooks across the whole repo on demand:
+
+```bash
+pre-commit run --all-files
+```
+
 ## Releases
 
 Releases are cut by pushing a `v<version>` tag that matches the `version`

--- a/inventory/__init__.py
+++ b/inventory/__init__.py
@@ -1,8 +1,9 @@
 """A toy inventory management library."""
 
-from importlib.metadata import PackageNotFoundError, version as _dist_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _dist_version
 
-from .models import Product, Warehouse, Order
+from .models import Order, Product, Warehouse
 from .pricing import apply_discount, compute_total
 from .reports import monthly_report, stock_alert
 

--- a/inventory/pricing.py
+++ b/inventory/pricing.py
@@ -66,7 +66,10 @@ def compute_total(
             behavior hides catalog-sync errors and produces under-priced
             totals; prefer pre-filtering ``order.items`` against ``catalog``::
 
-                known = [(sku, qty) for sku, qty in order.items if sku in catalog]
+                known = [
+                    (sku, qty) for sku, qty in order.items
+                    if sku in catalog
+                ]
                 filtered = Order(order_id=order.order_id, items=known,
                                  customer=order.customer)
                 compute_total(filtered, catalog, discount_pct)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,15 @@ test = [
     "pytest",
     "hypothesis",
 ]
+# Dependencies for the `lint` CI job and the `.pre-commit-config.yaml`
+# hooks. Versions are pinned exactly and MUST be kept in sync with the
+# `rev:` fields in `.pre-commit-config.yaml` — otherwise CI (which
+# installs from here) and local pre-commit runs will disagree. If you
+# bump one, bump the other in the same commit.
+lint = [
+    "ruff==0.3.7",
+    "flake8==7.3.0",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -54,3 +63,19 @@ include = ["inventory*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.ruff]
+# Minimum Python we still support (mirrors project.requires-python).
+target-version = "py310"
+# Keep line length aligned with flake8's default so the two tools agree.
+line-length = 79
+# Only lint our own code and tests; don't walk into generated/vendored dirs.
+include = ["inventory/**/*.py", "tests/**/*.py"]
+
+[tool.ruff.lint]
+# Ruff defaults are E + F (pycodestyle errors + pyflakes). Add W
+# (pycodestyle warnings, matches flake8's default) and I (isort).
+select = ["E", "F", "W", "I"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["inventory"]

--- a/tests/test_models_properties.py
+++ b/tests/test_models_properties.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 
 from copy import deepcopy
 
-from hypothesis import given, strategies as st
+from hypothesis import given
+from hypothesis import strategies as st
 
 from inventory.models import Warehouse
-
 
 # --- Strategies ------------------------------------------------------------
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -16,7 +16,8 @@ def test_version_is_pep440_ish():
     # is surfaced via importlib.metadata at import time.
     assert isinstance(inventory.__version__, str)
     assert re.match(
-        r"^\d+(\.\d+)+((a|b|rc)\d+)?(\.post\d+)?(\.dev\d+)?(\+[A-Za-z0-9.]+)?$",
+        r"^\d+(\.\d+)+((a|b|rc)\d+)?(\.post\d+)?"
+        r"(\.dev\d+)?(\+[A-Za-z0-9.]+)?$",
         inventory.__version__,
     ), f"not PEP 440-ish: {inventory.__version__!r}"
 
@@ -89,6 +90,7 @@ def test_version_falls_back_to_local_sentinel_when_dist_not_found(
         # checkout. This is the same regex used in
         # test_version_is_pep440_ish above, kept in sync intentionally.
         assert re.match(
-            r"^\d+(\.\d+)+((a|b|rc)\d+)?(\.post\d+)?(\.dev\d+)?(\+[A-Za-z0-9.]+)?$",
+            r"^\d+(\.\d+)+((a|b|rc)\d+)?(\.post\d+)?"
+            r"(\.dev\d+)?(\+[A-Za-z0-9.]+)?$",
             reloaded.__version__,
         ), reloaded.__version__

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -60,7 +60,8 @@ def test_compute_total_simple():
 def test_compute_total_with_discount():
     catalog = {"A": Product(sku="A", name="Apple", unit_price=10.0)}
     order = Order(order_id="o1", items=[("A", 2)])
-    assert compute_total(order, catalog, discount_pct=25.0) == pytest.approx(15.0)
+    total = compute_total(order, catalog, discount_pct=25.0)
+    assert total == pytest.approx(15.0)
 
 
 def test_compute_total_unknown_sku_raises():

--- a/tests/test_pricing_properties.py
+++ b/tests/test_pricing_properties.py
@@ -6,11 +6,11 @@ Tracked in GitHub issues #15 (compute_total linearity) and #17
 from __future__ import annotations
 
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import given
+from hypothesis import strategies as st
 
 from inventory.models import Order, Product
 from inventory.pricing import apply_discount, compute_total
-
 
 # --- Strategies ------------------------------------------------------------
 

--- a/tests/test_reports_properties.py
+++ b/tests/test_reports_properties.py
@@ -4,11 +4,11 @@ Tracked in GitHub issue #16.
 """
 from __future__ import annotations
 
-from hypothesis import given, strategies as st
+from hypothesis import given
+from hypothesis import strategies as st
 
 from inventory.models import Warehouse
 from inventory.reports import monthly_report
-
 
 # --- Strategies ------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds linting infrastructure (ruff + flake8) to the project: a pinned
`lint` optional dependency, a pre-commit config for local use, and a
separate CI lint job. Also fixes the handful of pre-existing line-
length and import-ordering nits that the new tools surface, so CI
lands green.

No changes to production code behavior.

## Added / changed

- **`pyproject.toml`**: new `[project.optional-dependencies].lint`
  extra pinning `ruff==0.3.7` and `flake8==7.3.0`. New `[tool.ruff]`
  block selecting `E`, `F`, `W`, `I` (defaults + isort), scoped to
  `inventory/` and `tests/`, line-length `79` to match flake8.
- **`.pre-commit-config.yaml`** *(new)*: three hook repos —
  `ruff-pre-commit v0.3.7` with `--fix`, `flake8 7.3.0`, and
  `pre-commit-hooks v4.6.0` for `end-of-file-fixer` and
  `trailing-whitespace`.
- **`.github/workflows/ci.yml`**: new `lint` job running in parallel
  with the existing `test` matrix on Ubuntu + Python 3.11, installing
  via `pip install -e .[lint]`.
- **`CONTRIBUTING.md`**: new "Development setup" section documenting
  the `test` and `lint` extras, how to run the tools locally, and how
  to install the pre-commit hooks.

Hook versions are pinned in two places (the `lint` extra and the
`.pre-commit-config.yaml` `rev:` fields) that MUST be kept in sync.
Inline comments in both files call out the sync requirement.

## Trivial lint fixups

Split out into a second commit so the config and the one-time cleanup
review independently:

- `inventory/pricing.py`: wrap a list-comprehension code example
  inside `compute_total`'s docstring.
- `tests/test_pricing.py`: extract a `compute_total(...)` call in
  `test_compute_total_with_discount` to a local before asserting on it.
- `tests/test_package.py`: split the PEP 440 regex literal at two
  test sites using implicit string concatenation. Adjacent string
  literals are concatenated at parse time, so the compiled pattern is
  byte-identical — suite still passes.
- Import-ordering (`I001`) auto-fixes in `inventory/__init__.py` and
  the three new `tests/test_*_properties.py` files, applied via
  `ruff check --fix`.

## Local verification

```
ruff check inventory tests   -> All checks passed!
flake8 inventory tests        -> (no output, exit 0)
pytest -q                     -> 50 passed in 1.03s
pre-commit run --all-files    -> ruff / flake8 / eof-fixer / trim-trailing-whitespace — all Passed
```

Closes #19.
