### PR TITLE
docs: add CI badges (tests/lint/mypy) and Unreleased changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Tests: property-based coverage (`tests/test_*_properties.py`) for
+  pricing, reports, and models invariants using Hypothesis.
+  Covers `compute_total` linearity, `apply_discount` monotonicity and
+  endpoint identities, `monthly_report` distributivity over partitions
+  and order-independence, and `Warehouse.add` + `remove` round-trips.
+  Also pins `monthly_report`'s zero-quantity SKU preservation behavior
+  with targeted regression tests. See PR #22.
+- CI: `lint` job (ruff + flake8) and `typecheck` job (mypy) running in
+  parallel with the existing test matrix. Tool versions pinned via the
+  new `lint` and `typecheck` optional-dependency extras in
+  `pyproject.toml`. Pre-commit config (`ruff --fix`, flake8,
+  `end-of-file-fixer`, `trailing-whitespace`) and contributor docs
+  added. See PRs #23, #24.
+
 ## [0.1.2rc1] - 2026-04-24
 
 Pre-release on TestPyPI only. First release cut via PyPI Trusted

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # inventory-pricing
 
-[![CI](https://github.com/dingxianzhong/inventory-pricing/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/dingxianzhong/inventory-pricing/actions/workflows/ci.yml)
+[![tests](https://img.shields.io/github/check-runs/dingxianzhong/inventory-pricing/main?nameFilter=pytest%20%28py3.11%20%2F%20ubuntu-latest%29&label=tests)](https://github.com/dingxianzhong/inventory-pricing/actions/workflows/ci.yml)
+[![lint](https://img.shields.io/github/check-runs/dingxianzhong/inventory-pricing/main?nameFilter=lint%20%28ruff%20%2B%20flake8%29&label=lint)](https://github.com/dingxianzhong/inventory-pricing/actions/workflows/ci.yml)
+[![mypy](https://img.shields.io/github/check-runs/dingxianzhong/inventory-pricing/main?nameFilter=mypy&label=mypy)](https://github.com/dingxianzhong/inventory-pricing/actions/workflows/ci.yml)
 
 Toy inventory-management library.
 


### PR DESCRIPTION
## Summary

Follow-up to PRs #22, #23, and #24. Updates user-facing docs to reflect
the new CI jobs and property-based test coverage:

- Adds three per-job CI status badges to `README.md` (tests / lint / mypy).
- Opens a new `[Unreleased]` section in `CHANGELOG.md` summarizing the
  three recent PRs under `### Added`.

No code changes; no test/lint/mypy surface affected.

## Badge choice

The badges use `img.shields.io/github/check-runs/...` with
`nameFilter=` pointing at each job's name. This lets us show three
separate per-job badges against our single-workflow CI setup (GitHub's
own `badge.svg` endpoint only supports filtering by workflow file, not
by job).

One caveat worth noting: the `tests` badge tracks a single
representative matrix cell (`pytest (py3.11 / ubuntu-latest)`) rather
than the full 12-cell matrix, because the check-runs endpoint can't
aggregate across cells. In practice cells rarely diverge — if 3.11/
ubuntu fails, the other cells generally fail with it — and all three
badges link back to the full Actions page where the complete matrix
is visible.

## Local verification

```
ruff check inventory tests   -> All checks passed!
flake8 inventory tests        -> (no output, exit 0)
mypy inventory                -> Success: no issues found in 4 source files
pytest -q                     -> 50 passed in 0.88s
pre-commit run --all-files    -> all hooks Passed
```
