### PR TITLE
spike(models): experimental Warehouse(delete_on_zero=False)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `end-of-file-fixer`, `trailing-whitespace`) and contributor docs
   added. See PRs #23, #24.
 - `inventory.models.Warehouse` — experimental `delete_on_zero`
-  constructor flag (default `False`). When `True`, `remove(sku, qty)`
-  deletes the SKU from `stock` when its count reaches `0`. Default
-  preserves existing behavior; no `DeprecationWarning` emitted either
-  way. This is a spike for the Option A proposal in #21 and may change
-  or be removed based on that issue's resolution.
+  constructor flag (default `False`, default-off, no behavior change).
+  When `True`, `remove(sku, qty)` deletes the SKU from `stock` on
+  reaching `0`. Spike for #21; API may change or be removed based on
+  that issue's resolution. See PR #26.
 
 ## [0.1.2rc1] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `pyproject.toml`. Pre-commit config (`ruff --fix`, flake8,
   `end-of-file-fixer`, `trailing-whitespace`) and contributor docs
   added. See PRs #23, #24.
+- `inventory.models.Warehouse` — experimental `delete_on_zero`
+  constructor flag (default `False`). When `True`, `remove(sku, qty)`
+  deletes the SKU from `stock` when its count reaches `0`. Default
+  preserves existing behavior; no `DeprecationWarning` emitted either
+  way. This is a spike for the Option A proposal in #21 and may change
+  or be removed based on that issue's resolution.
 
 ## [0.1.2rc1] - 2026-04-24
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ python -m pytest tests/ -v
   its count reaches `0`, so `stock` only ever contains positive counts
   and `add(new_sku, n) + remove(new_sku, n)` is a true no-op.
 
+  ```python
+  from inventory.models import Warehouse
+
+  # Default behavior (unchanged): zero-stock SKUs linger in `stock`.
+  w = Warehouse(name="w", stock={"A": 3})
+  w.remove("A", 3)
+  assert w.stock == {"A": 0}   # "A" still present with value 0
+
+  # Opt-in: zero-stock SKUs are removed from `stock`.
+  w = Warehouse(name="w", stock={"A": 3}, delete_on_zero=True)
+  w.remove("A", 3)
+  assert w.stock == {}          # "A" deleted on reaching 0
+  ```
+
   The default (`False`) preserves existing behavior exactly — SKUs
   removed to zero remain in `stock` with value `0`, and `monthly_report`
   and `stock_alert(threshold=0)` continue to see them.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ python -m pytest tests/ -v
   its count reaches `0`, so `stock` only ever contains positive counts
   and `add(new_sku, n) + remove(new_sku, n)` is a true no-op.
 
+  Design context and deprecation-timeline options are written up in
+  [RFC 021](docs/rfcs/021-delete-on-zero.md).
+
   ```python
   from inventory.models import Warehouse
 

--- a/README.md
+++ b/README.md
@@ -129,3 +129,18 @@ python -m pytest tests/ -v
   with `qty == threshold` is reported.
 - `inventory.pricing.bulk_price` applies the 10% discount at `qty >= 100`
   (boundary included).
+- `inventory.models.Warehouse` has an **experimental `delete_on_zero`
+  constructor flag** (default `False`). When set to `True`,
+  `Warehouse.remove(sku, qty)` deletes the SKU from `stock` as soon as
+  its count reaches `0`, so `stock` only ever contains positive counts
+  and `add(new_sku, n) + remove(new_sku, n)` is a true no-op.
+
+  The default (`False`) preserves existing behavior exactly — SKUs
+  removed to zero remain in `stock` with value `0`, and `monthly_report`
+  and `stock_alert(threshold=0)` continue to see them.
+
+  This flag is an opt-in toggle for the Option A proposal in
+  [#21](https://github.com/dingxianzhong/inventory-pricing/issues/21)
+  and may change or be removed based on that issue's resolution. No
+  deprecation warning is emitted by either default; this is a spike
+  for feedback, not a committed API.

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -29,10 +29,22 @@ class Warehouse:
         ``stock_alert(threshold=0)``. Whether to collapse the two states
         is tracked as a design decision in issue #21:
         https://github.com/dingxianzhong/inventory-pricing/issues/21
+
+        The ``delete_on_zero`` constructor flag (default ``False``) is
+        an **experimental opt-in** toggle for the Option A behavior
+        proposed in #21: when ``True``, ``remove(sku, qty)`` deletes
+        the SKU from ``stock`` as soon as its count reaches ``0``, so
+        ``stock`` only ever contains positive counts. Default-off,
+        no warnings, no behavior change for existing callers; exists
+        purely to let downstreams experiment. Interface may change or
+        disappear in a future release based on #21's resolution.
     """
 
     name: str
     stock: dict[str, int] = field(default_factory=dict)
+    # Experimental — see class docstring and issue #21. Default False
+    # preserves existing behavior exactly.
+    delete_on_zero: bool = False
 
     def add(self, sku: str, qty: int) -> None:
         self.stock[sku] = self.stock.get(sku, 0) + qty
@@ -42,6 +54,8 @@ class Warehouse:
         if self.stock.get(sku, 0) < qty:
             return False
         self.stock[sku] -= qty
+        if self.delete_on_zero and self.stock[sku] == 0:
+            del self.stock[sku]
         return True
 
     def available(self, sku: str) -> int:

--- a/tests/test_warehouse_delete_on_zero.py
+++ b/tests/test_warehouse_delete_on_zero.py
@@ -1,0 +1,126 @@
+"""Tests for the experimental Warehouse(delete_on_zero=...) flag.
+
+See issue #21 for the design discussion. These tests exercise the
+opt-in behavior (delete the SKU from stock when remove takes the
+count to zero). Default-off behavior is already covered by the
+existing Warehouse tests in test_models.py.
+"""
+from __future__ import annotations
+
+from inventory.models import Warehouse
+
+# --- Opt-in (delete_on_zero=True) -----------------------------------------
+
+
+def test_remove_to_zero_deletes_key_when_flag_enabled():
+    w = Warehouse(name="w", stock={"A": 3}, delete_on_zero=True)
+    assert w.remove("A", 3) is True
+    assert "A" not in w.stock
+    assert w.stock == {}
+
+
+def test_add_then_remove_new_sku_leaves_it_absent_when_flag_enabled():
+    """The round-trip invariant the strengthened Option A would enable:
+    add(new_sku, n) + remove(new_sku, n) is a true no-op on stock.
+    """
+    w = Warehouse(name="w", delete_on_zero=True)
+    w.add("NEW", 5)
+    assert w.remove("NEW", 5) is True
+    assert "NEW" not in w.stock
+    assert w.stock == {}
+
+
+def test_add_then_remove_existing_sku_restores_exactly_when_flag_enabled():
+    """Strict identity on pre-existing SKUs: the starting stock is
+    restored byte-for-byte, and the SKU is NOT spuriously deleted
+    just because it touched zero transiently during the round-trip.
+
+    (It doesn't touch zero here — we add first, then remove — but
+    this test pins the expectation that delete_on_zero doesn't affect
+    SKUs whose final count is positive.)
+    """
+    w = Warehouse(name="w", stock={"A": 4, "B": 1}, delete_on_zero=True)
+    w.add("A", 2)
+    assert w.remove("A", 2) is True
+    assert w.stock == {"A": 4, "B": 1}
+
+
+def test_remove_to_positive_does_not_delete_key_when_flag_enabled():
+    """Only the exact-to-zero case triggers deletion; positive residue
+    leaves the key untouched.
+    """
+    w = Warehouse(name="w", stock={"A": 5}, delete_on_zero=True)
+    assert w.remove("A", 2) is True
+    assert w.stock == {"A": 3}
+
+
+def test_flag_enabled_does_not_affect_insufficient_remove():
+    """remove returns False when stock is too low; dict is unchanged
+    regardless of the flag.
+    """
+    w = Warehouse(name="w", stock={"A": 2}, delete_on_zero=True)
+    assert w.remove("A", 5) is False
+    assert w.stock == {"A": 2}
+
+
+def test_flag_enabled_does_not_affect_remove_from_missing_sku():
+    w = Warehouse(name="w", delete_on_zero=True)
+    assert w.remove("A", 1) is False
+    assert w.stock == {}
+    assert "A" not in w.stock
+
+
+def test_flag_enabled_does_not_change_add_behavior():
+    """add(sku, 0) still creates a {sku: 0} entry even with the flag on
+    — the flag is scoped to remove's post-condition, not add's.
+    """
+    w = Warehouse(name="w", delete_on_zero=True)
+    w.add("A", 0)
+    assert w.stock == {"A": 0}
+    assert "A" in w.stock
+
+
+# --- Default (delete_on_zero=False) — sanity regression -------------------
+
+
+def test_default_flag_value_is_false():
+    """The default must remain False so that pre-flag callers see no
+    behavior change. Pinning this explicitly so a later bump of the
+    default is an obvious, deliberate change.
+    """
+    w = Warehouse(name="w")
+    assert w.delete_on_zero is False
+
+
+def test_default_preserves_zero_entry_after_remove():
+    """Status-quo behavior: remove-to-zero leaves {sku: 0} in stock."""
+    w = Warehouse(name="w", stock={"A": 3})
+    assert w.remove("A", 3) is True
+    assert w.stock == {"A": 0}
+    assert "A" in w.stock
+
+
+# --- Downstream effects under the opt-in flag -----------------------------
+
+
+def test_stock_alert_under_flag_does_not_see_deleted_sku():
+    """Documents the key downstream effect called out in the #21 RFC:
+    a SKU removed-to-zero under the flag is invisible to stock_alert,
+    including stock_alert(threshold=0). Not asserting this is "good"
+    — just pinning the observable behavior for reviewers.
+    """
+    from inventory.reports import stock_alert
+    w = Warehouse(name="w", stock={"A": 3}, delete_on_zero=True)
+    w.remove("A", 3)
+    assert stock_alert(w, threshold=0) == []
+
+
+def test_monthly_report_under_flag_omits_deleted_sku():
+    """Companion to the above: monthly_report also no longer reports
+    the SKU. Compare with the existing #14 regression tests in
+    test_reports.py, which assert the opposite under the default.
+    """
+    from inventory.reports import monthly_report
+    w = Warehouse(name="w", stock={"A": 3}, delete_on_zero=True)
+    w.remove("A", 3)
+    assert monthly_report([w]) == {}


### PR DESCRIPTION
## Summary

Draft spike implementing **Option A** from the RFC on issue #21:
`Warehouse.remove(sku, qty)` deletes the SKU from `stock` when its
count reaches `0`, controlled by a new constructor flag.

This is intentionally minimal: no deprecation warning, no migration
timeline, default preserves existing behavior exactly. Purpose is to
let reviewers play with the shape of the flag and observe the
downstream effects on `monthly_report` and `stock_alert` before any
commitment is made on #21.

**Not for merge yet.** Draft status until #21 reaches a decision.

## What's in

- **`inventory/models.py`** — new `delete_on_zero: bool = False`
  field on `Warehouse`. Conditional `del self.stock[sku]` in
  `remove()` when the count hits exactly zero under the flag. Class
  docstring extended to document the experimental flag and link to
  #21.
- **`tests/test_warehouse_delete_on_zero.py`** *(new)* — 11 focused
  tests:
  - 7 opt-in tests exercising the flag-enabled path (remove-to-zero
    deletes the key; `add(new, n)` + `remove(new, n)` leaves the new
    SKU absent from `stock`; round-trip on an existing SKU still
    restores exact identity; remove-to-positive and
    remove-from-missing-SKU behavior unchanged; `add` behavior
    unchanged).
  - 2 default-preserving sanity tests (the flag defaults to `False`;
    remove-to-zero still leaves `{sku: 0}`).
  - 2 tests documenting the observable effect on `stock_alert` and
    `monthly_report` under the flag. These are deliberately factual
    ("under the flag, `monthly_report` omits the SKU") rather than
    prescriptive ("this is correct"), to make the downstream
    behavior legible in a review.
- **`README.md`** — new subsection under "Behavioral notes /
  breaking changes" describing the flag and linking to #21.
- **`CHANGELOG.md`** — one-paragraph `[Unreleased]` entry flagging
  the API as experimental.

## What's deliberately not in

- **No `DeprecationWarning`** on either default. The RFC on #21
  sketches a 0.2.0 → 0.3.0 → 1.0.0 deprecation dance, but that ties
  us to a migration path before #21 has even been resolved. Adding
  it here would be premature.
- **No `Optional[bool] = None` sentinel.** The RFC notes that the
  sentinel pattern is what we'd want if we were emitting a "you
  didn't choose" warning. Since we're not warning, a plain `bool =
  False` is sufficient; swapping to a sentinel is a one-commit
  change when the deprecation timeline is decided.
- **No changes to `monthly_report` / `stock_alert`.** These see the
  effect of the flag indirectly (a SKU deleted by `remove` is no
  longer visible to either). The two tests at the end of the new
  test file pin that observable effect without endorsing it — the
  question of whether that's desirable is exactly what #21 is for.
- **No changes to existing #14 or #18 regression tests.** They all
  still pass because the flag defaults to `False` and those tests
  don't set it.

## Local verification

```
ruff check inventory tests   -> All checks passed!
flake8 inventory tests        -> (no output, exit 0)
mypy inventory                -> Success: no issues found in 4 source files
pre-commit run --all-files    -> all 4 hooks Passed
pytest -v                     -> 61 passed in 1.00s
```

(Was 50 tests on `main`; +11 new in the spike.)

## References

- RFC on the design decision: #21
- Background on "present at 0" vs. "absent SKU" semantics the flag
  affects: #14, #18
